### PR TITLE
seed mock charts from yaml

### DIFF
--- a/chartdir/mychart.yaml
+++ b/chartdir/mychart.yaml
@@ -1,0 +1,14 @@
+---
+
+interval_seconds: 2
+name: "My Chart"
+key: "mychart"
+length: 60
+y_axes:
+ -
+   name: "hits"
+   function_type: "black_friday"
+ -
+   name: "pyramid"
+   function_type: "sawtooth"
+...

--- a/charts/import.go
+++ b/charts/import.go
@@ -1,0 +1,100 @@
+package charts
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/ghodss/yaml"
+)
+
+func parseFile(dir, fileName string) []byte {
+	f, err := os.Open(dir + "/" + fileName)
+	if err != nil {
+		log.Error("Could not import schema: ", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	parsedFile := []byte{}
+
+	// read each line
+	for scanner.Scan() {
+
+		// replace any tabs with spaces, because YAML does NOT like tabs
+		parsedLine := scanner.Bytes()
+		parsedLine = bytes.Replace(parsedLine, []byte{9}, []byte(" "), -1)
+		parsedLine = append(parsedLine, byte(10))
+		parsedFile = append(parsedFile, parsedLine...)
+	}
+
+	return parsedFile
+}
+
+func importChart(dir, fileName string) []byte {
+
+	chart := []byte{}
+	_, err := os.Stat(dir + "/" + fileName)
+	if err != nil {
+		log.Error(fileName, ": filename does not exist. no default data has been seeded.")
+		return chart
+	}
+
+	chart = parseFile(dir, fileName)
+	return chart
+}
+
+func SeedCharts(dir string) {
+	log.Info("Importing schemas for charts...")
+	files, _ := ioutil.ReadDir(dir)
+	for _, file := range files {
+		template := importChart(dir, file.Name())
+
+		m, err := unmarshalYaml(template)
+		if err != nil {
+			log.Error("Could not unmarshal Yaml ", file.Name(), ": ", err)
+			continue
+		}
+
+		createChart(m)
+	}
+
+	return
+}
+
+func createChart(c map[string]interface{}) {
+	log.Info("Executing Create New Chart")
+
+	// create new chart
+	// TODO: check all hashes to make sure they exist
+	s := NewSet(c["name"].(string), c["key"].(string), int(c["length"].(float64)), int(c["interval_seconds"].(float64)))
+	if s == nil {
+		log.Error("Malformed request: Length or Interval")
+		return
+	}
+	// add y axes
+	for _, y := range c["y_axes"].([]interface{}) {
+		yaxis := y.(map[string]interface{})
+		f := yaxis["function_type"].(string)
+		n := yaxis["name"].(string)
+		err := s.AddYAxis(n, Functions[f])
+		if err != nil {
+			return
+		}
+	}
+
+	// start it
+	s.Run()
+	log.Info("Created chart ", c["name"].(string), " at endpoint /charts/", c["key"].(string))
+}
+
+func unmarshalYaml(b []byte) (map[string]interface{}, error) {
+	s := new(map[string]interface{})
+	err := yaml.Unmarshal(b, &s)
+	if err != nil {
+		return nil, err
+	}
+	return *s, nil
+}

--- a/http/handlers/charts.go
+++ b/http/handlers/charts.go
@@ -9,20 +9,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-type Chart struct {
-	Name          string  `json:"name"`
-	Key           string  `json:"key"`
-	NumDataPoints float64 `json:"num_data_points"`
-	IntervalS     float64 `json:"interval_seconds"`
-	Active        bool    `json:"active"`
-	YAxes         []YAxis `json:"y_axes"`
-}
-
-type YAxis struct {
-	Name         string `json:"name"`
-	FunctionType string `json:"function_type"`
-}
-
 func ReadChart(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	key := ps.ByName("key")
 	log.Info("Retrieving chart data for ", key)
@@ -38,49 +24,7 @@ func ReadChart(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 }
 
 func GetCharts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	log.Info("Executing ListSets()")
+	log.Info("Retrieving list of charts")
 	data := charts.ListSets()
 	helpers.Respond(w, data, http.StatusOK)
-}
-
-func CreateChart(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	log.Info("Executing Create New Chart")
-	c := &Chart{}
-	err := helpers.GetRequestBody(r, c)
-	if err != nil {
-		log.Error("Malformed request: ", err)
-		helpers.Respond(w, err, http.StatusBadRequest)
-		return
-	}
-	// TODO: check y axis function exists
-
-	// create new chart
-	s := charts.NewSet(c.Name, c.Key, int(c.NumDataPoints), int(c.IntervalS))
-	if s == nil {
-		log.Error("Malformed request: Length or Interval")
-		// TODO fix the error stuff to accept variadic status
-		helpers.Respond(w, "Malformed request: Length or Interval missing.", http.StatusBadRequest)
-		return
-	}
-	// add y axes
-	for _, y := range c.YAxes {
-		err := s.AddYAxis(y.Name, charts.Functions[y.FunctionType])
-		if err != nil {
-			helpers.Respond(w, "Malformed request: Function does not exist", http.StatusBadRequest)
-			return
-		}
-	}
-
-	// start it
-	s.Run()
-	c.Active = s.IsActive()
-	c.Key = s.Key
-
-	helpers.Respond(w, c, http.StatusOK)
-}
-
-func DeleteChart(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	key := ps.ByName("key")
-	charts.DeleteSet(key)
-	helpers.Respond(w, nil, http.StatusOK)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -61,6 +61,4 @@ func AddCrudRoutes(endpoints []string) {
 func AddChartRoutes() {
 	router.GET("/charts", handlers.GetCharts)
 	router.GET("/charts/:key", handlers.ReadChart)
-	router.POST("/charts", handlers.CreateChart)
-	router.DELETE("/charts/:key", handlers.DeleteChart)
 }

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/Teradata/covalent-data/charts"
 	"github.com/Teradata/covalent-data/crud"
 	"github.com/Teradata/covalent-data/router"
 )
@@ -18,11 +19,13 @@ func main() {
 	// directories to look for schema and datum data
 	schemaDir := f + "/schemas"
 	datumDir := f + "/datum"
+	chartDir := f + "/chartdir"
 
 	// define command line flags here.
 	port := flag.String("port", "8080", "port to listen on")
 	sDir := flag.String("schemadir", schemaDir, "absolute directory where schemas are located")
 	dDir := flag.String("datumdir", datumDir, "absolute directory where datum is located")
+	cDir := flag.String("chartdir", chartDir, "absolute directory where charts located")
 	flag.Parse()
 
 	// copyright and stuff.
@@ -42,10 +45,12 @@ func main() {
 	// import schemas and mock data
 	log.Info("Importing schemas for CRUD objects and seeding initial mock data...")
 	routes := crud.SeedDB(*sDir, *dDir)
+	charts.SeedCharts(*cDir)
 
 	// add generated endpoints for imported schema objects
 	log.Info("Adding HTTP routes for object CRUD endpoints...")
 	router.AddCrudRoutes(routes)
+	log.Info("Adding HTTP routes for mock chart data endpoints...")
 	router.AddChartRoutes()
 
 	// start the router and server


### PR DESCRIPTION
## Description

This PR moves the mock chart data creation from REST endpoints to static yaml flies to conform with the rest of Covalent-Data

### What's included?

- Created a `/chartdir` directory for mock chart yaml files
- Removed `POST /charts` endpoint for creating mock charts

#### Test Steps

- [x] look at `chartdir/mychart.yaml`
- [x] install [Docker Engine](https://docs.docker.com/engine/installation/)
- [x] in this directory, `docker build -t covalent-data .`
- [x] `docker run -p 8080:8080 --name covalent-data covalent-data` (`docker stop covalent-data` to stop)
- [x] `GET` to `http://localhost:8080/charts`, and check to see `My Chart` listed as one of the charts.
- [x] `GET` to `http://localhost:8080/charts/mychart` - you should get chart data returned as an array.  Repeat this step to see the chart data update.
