### PR TITLE
add compatability with ng2d3 area chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.8
 
 ADD . /go/src/github.com/Teradata/covalent-data
 WORKDIR /go/src/github.com/Teradata/covalent-data

--- a/charts/charts.go
+++ b/charts/charts.go
@@ -41,6 +41,7 @@ type Set struct {
 	lock      sync.Mutex
 	x         *xAxis
 	ys        []*yAxis
+	ng2d3     bool
 }
 
 // GetSetData returns an array of data points from the existing set.
@@ -57,6 +58,23 @@ func GetSetData(key string, length int) (*[]map[string]interface{}, int) {
 	}
 
 	ma := []map[string]interface{}{}
+
+	if s.ng2d3 {
+		for k, y := range s.ys {
+			series := []map[string]interface{}{}
+			for i := 0; i < length; i++ {
+				m := s.popD3(i)[k]
+				series = append(series, m)
+			}
+			yAxisData := map[string]interface{}{
+				"series": series,
+				"name":   y.name,
+			}
+			ma = append(ma, yAxisData)
+		}
+
+		return &ma, total
+	}
 
 	for i := 0; i < length; i++ {
 		m := s.pop(i)
@@ -123,6 +141,7 @@ func NewSet(name string, key string, l int, intervalS int) *Set {
 		stop:      make(chan bool),
 		created:   time.Now().Unix(),
 		ys:        []*yAxis{},
+		ng2d3:     false,
 	}
 
 	return Sets[key]
@@ -237,5 +256,24 @@ func (s *Set) pop(i int) map[string]interface{} {
 		}
 		s.length.current--
 	}
+	return m
+}
+
+func (s *Set) popD3(i int) []map[string]interface{} {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.length.current == 0 {
+		return nil
+	}
+
+	m := []map[string]interface{}{}
+
+	for k, _ := range s.ys {
+		t := map[string]interface{}{}
+		t["name"] = s.x.values[i]
+		t["value"] = s.ys[k].values[i]
+		m = append(m, t)
+	}
+
 	return m
 }

--- a/charts/charts.go
+++ b/charts/charts.go
@@ -41,7 +41,7 @@ type Set struct {
 	lock      sync.Mutex
 	x         *xAxis
 	ys        []*yAxis
-	ng2d3     bool
+	ngx       bool
 }
 
 // GetSetData returns an array of data points from the existing set.
@@ -59,7 +59,7 @@ func GetSetData(key string, length int) (*[]map[string]interface{}, int) {
 
 	ma := []map[string]interface{}{}
 
-	if s.ng2d3 {
+	if s.ngx {
 		for k, y := range s.ys {
 			series := []map[string]interface{}{}
 			for i := 0; i < length; i++ {
@@ -141,7 +141,7 @@ func NewSet(name string, key string, l int, intervalS int) *Set {
 		stop:      make(chan bool),
 		created:   time.Now().Unix(),
 		ys:        []*yAxis{},
-		ng2d3:     false,
+		ngx:       false,
 	}
 
 	return Sets[key]

--- a/charts/import.go
+++ b/charts/import.go
@@ -75,9 +75,9 @@ func createChart(c map[string]interface{}) {
 		return
 	}
 
-	// ng2d3 compatability
-	if v, ok := c["ng2d3"].(bool); ok {
-		s.ng2d3 = v
+	// ngx-charts compatability
+	if v, ok := c["ngx"].(bool); ok {
+		s.ngx = v
 	}
 
 	// add y axes

--- a/charts/import.go
+++ b/charts/import.go
@@ -74,6 +74,12 @@ func createChart(c map[string]interface{}) {
 		log.Error("Malformed request: Length or Interval")
 		return
 	}
+
+	// ng2d3 compatability
+	if v, ok := c["ng2d3"].(bool); ok {
+		s.ng2d3 = v
+	}
+
 	// add y axes
 	for _, y := range c["y_axes"].([]interface{}) {
 		yaxis := y.(map[string]interface{})

--- a/config/chartdir/mychart.yaml
+++ b/config/chartdir/mychart.yaml
@@ -13,6 +13,9 @@ length: 60
 # json name of x_axis data
 x_axis_name: "timestamp"
 
+# ng2d3 consumable data
+ng2d3: true
+
 # string timestamp format of x_axis data
 # you MUST use the following values if formatting your own custom string:
 # Mon, Jan, 2, 15:04:05, 2006, -7

--- a/config/chartdir/mychart.yaml
+++ b/config/chartdir/mychart.yaml
@@ -13,8 +13,8 @@ length: 60
 # json name of x_axis data
 x_axis_name: "timestamp"
 
-# ng2d3 consumable data
-ng2d3: true
+# ngx-charts consumable data
+ngx: true
 
 # string timestamp format of x_axis data
 # you MUST use the following values if formatting your own custom string:


### PR DESCRIPTION
## Description

This PR adds compatability for [ngx](https://github.com/swimlane/ngx-charts) area charts.  More to come.

### What's included?

- yaml key `ngx: true` in `chartdir/chart.yaml` will format data for consumption by ngx area charts.

#### Test Steps

- [x] install [Docker Engine](https://docs.docker.com/engine/installation/)
- [x] in this directory, `docker build -t covalent-data .`
- [x] `docker run -p 8080:8080 --name covalent-data covalent-data` (`docker stop covalent-data; docker rm covalent-data` to stop and remove the container)
- [x] go to http://localhost:8080/charts/mychart
